### PR TITLE
Pin ImGui to v1.91.9-docking to fix font atlas init crash in proton (linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, p2p-beta ]
+    branches: [ main, p2p-beta, proton-debug ]
   pull_request:
-    branches: [ main, p2p-beta ]
+    branches: [ main, p2p-beta, proton-debug ]
 
 jobs:
   build-and-test:

--- a/Source/Payday3-Internal/DLLMain.cpp
+++ b/Source/Payday3-Internal/DLLMain.cpp
@@ -56,7 +56,7 @@ bool Init()
 	if (!result) {
 		Globals::g_upConsole->SetVisibility(true);
 		Utils::LogError("Offset auto updating failed! Using fallback offsets. The internal may not work correctly or may even crash!");
-		std::this_thread::sleep_for(std::chrono::seconds(10));
+		std::this_thread::sleep_for(std::chrono::seconds(3));
 	} else {
 		const UEOffsets::Offsets& offsets = result.value();
 		SDK::Offsets::GObjects = offsets.GObjects;
@@ -65,14 +65,13 @@ bool Init()
 		SDK::Offsets::ProcessEvent = offsets.ProcessEvent;
 		SDK::Offsets::ProcessEventIdx = offsets.ProcessEventIdx;
 
-		Globals::g_upConsole->SetVisibility(true);
-		Utils::LogError("Offsets updated successfully:");
-		Utils::LogError(std::format("GObjects: 0x{:08X}", offsets.GObjects));
-		Utils::LogError(std::format("AppendString: 0x{:08X}", offsets.AppendString));
-		Utils::LogError(std::format("GNames: 0x{:08X}", offsets.GNames));
-		Utils::LogError(std::format("GWorld: 0x{:08X}", offsets.GWorld));
-		Utils::LogError(std::format("ProcessEvent: 0x{:08X}", offsets.ProcessEvent));
-		Utils::LogError(std::format("ProcessEventIdx: 0x{:08X}", offsets.ProcessEventIdx));
+		Utils::LogDebug("Offsets updated successfully:");
+		Utils::LogDebug(std::format("GObjects: 0x{:08X}", offsets.GObjects));
+		Utils::LogDebug(std::format("AppendString: 0x{:08X}", offsets.AppendString));
+		Utils::LogDebug(std::format("GNames: 0x{:08X}", offsets.GNames));
+		Utils::LogDebug(std::format("GWorld: 0x{:08X}", offsets.GWorld));
+		Utils::LogDebug(std::format("ProcessEvent: 0x{:08X}", offsets.ProcessEvent));
+		Utils::LogDebug(std::format("ProcessEventIdx: 0x{:08X}", offsets.ProcessEventIdx));
 	}
 	std::chrono::time_point offsetEndTime = std::chrono::high_resolution_clock::now();
 
@@ -118,20 +117,17 @@ bool Init()
 	int32_t iFramerateLimit = SDK::USBZSettingsFunctionsVideo::GetFramerateLimit(pGWorld);
 	Utils::LogDebug(std::format("GWorld pointer acquired: 0x{:016X}", reinterpret_cast<uint64_t>(pGWorld)));
 
-	Utils::LogError("[init-stage] Before MH_Initialize");
 	if (MH_Initialize() != MH_OK) {
 		Globals::g_upConsole->SetVisibility(true);
 		Utils::LogError("Failed to initialize MinHook library!");
 		return false;
 	}
-	Utils::LogError("[init-stage] After MH_Initialize, before Dx12Hook::Initialize");
 
     if (!Dx12Hook::Initialize()) {
         Globals::g_upConsole->SetVisibility(true);
         Utils::LogError("Failed to initialize DirectX 12 hook!");
         return false;
     }
-    Utils::LogError("[init-stage] After Dx12Hook::Initialize");
 
 	SDK::USBZSettingsFunctionsVideo::SetFramerateLimit(pGWorld, iFramerateLimit);
 	return true;

--- a/Source/Payday3-Internal/DLLMain.cpp
+++ b/Source/Payday3-Internal/DLLMain.cpp
@@ -56,7 +56,7 @@ bool Init()
 	if (!result) {
 		Globals::g_upConsole->SetVisibility(true);
 		Utils::LogError("Offset auto updating failed! Using fallback offsets. The internal may not work correctly or may even crash!");
-		std::this_thread::sleep_for(std::chrono::seconds(3));
+		std::this_thread::sleep_for(std::chrono::seconds(10));
 	} else {
 		const UEOffsets::Offsets& offsets = result.value();
 		SDK::Offsets::GObjects = offsets.GObjects;
@@ -65,13 +65,14 @@ bool Init()
 		SDK::Offsets::ProcessEvent = offsets.ProcessEvent;
 		SDK::Offsets::ProcessEventIdx = offsets.ProcessEventIdx;
 
-		Utils::LogDebug("Offsets updated successfully:");
-		Utils::LogDebug(std::format("GObjects: 0x{:08X}", offsets.GObjects));
-		Utils::LogDebug(std::format("AppendString: 0x{:08X}", offsets.AppendString));
-		Utils::LogDebug(std::format("GNames: 0x{:08X}", offsets.GNames));
-		Utils::LogDebug(std::format("GWorld: 0x{:08X}", offsets.GWorld));
-		Utils::LogDebug(std::format("ProcessEvent: 0x{:08X}", offsets.ProcessEvent));
-		Utils::LogDebug(std::format("ProcessEventIdx: 0x{:08X}", offsets.ProcessEventIdx));
+		Globals::g_upConsole->SetVisibility(true);
+		Utils::LogError("Offsets updated successfully:");
+		Utils::LogError(std::format("GObjects: 0x{:08X}", offsets.GObjects));
+		Utils::LogError(std::format("AppendString: 0x{:08X}", offsets.AppendString));
+		Utils::LogError(std::format("GNames: 0x{:08X}", offsets.GNames));
+		Utils::LogError(std::format("GWorld: 0x{:08X}", offsets.GWorld));
+		Utils::LogError(std::format("ProcessEvent: 0x{:08X}", offsets.ProcessEvent));
+		Utils::LogError(std::format("ProcessEventIdx: 0x{:08X}", offsets.ProcessEventIdx));
 	}
 	std::chrono::time_point offsetEndTime = std::chrono::high_resolution_clock::now();
 
@@ -117,17 +118,20 @@ bool Init()
 	int32_t iFramerateLimit = SDK::USBZSettingsFunctionsVideo::GetFramerateLimit(pGWorld);
 	Utils::LogDebug(std::format("GWorld pointer acquired: 0x{:016X}", reinterpret_cast<uint64_t>(pGWorld)));
 
+	Utils::LogError("[init-stage] Before MH_Initialize");
 	if (MH_Initialize() != MH_OK) {
 		Globals::g_upConsole->SetVisibility(true);
 		Utils::LogError("Failed to initialize MinHook library!");
 		return false;
 	}
+	Utils::LogError("[init-stage] After MH_Initialize, before Dx12Hook::Initialize");
 
     if (!Dx12Hook::Initialize()) {
         Globals::g_upConsole->SetVisibility(true);
         Utils::LogError("Failed to initialize DirectX 12 hook!");
         return false;
     }
+    Utils::LogError("[init-stage] After Dx12Hook::Initialize");
 
 	SDK::USBZSettingsFunctionsVideo::SetFramerateLimit(pGWorld, iFramerateLimit);
 	return true;

--- a/Source/Payday3-Internal/DLLMain.cpp
+++ b/Source/Payday3-Internal/DLLMain.cpp
@@ -117,17 +117,20 @@ bool Init()
 	int32_t iFramerateLimit = SDK::USBZSettingsFunctionsVideo::GetFramerateLimit(pGWorld);
 	Utils::LogDebug(std::format("GWorld pointer acquired: 0x{:016X}", reinterpret_cast<uint64_t>(pGWorld)));
 
+	Utils::LogDebug("[init-stage] Before MH_Initialize");
 	if (MH_Initialize() != MH_OK) {
 		Globals::g_upConsole->SetVisibility(true);
 		Utils::LogError("Failed to initialize MinHook library!");
 		return false;
 	}
+	Utils::LogDebug("[init-stage] After MH_Initialize, before Dx12Hook::Initialize");
 
     if (!Dx12Hook::Initialize()) {
         Globals::g_upConsole->SetVisibility(true);
         Utils::LogError("Failed to initialize DirectX 12 hook!");
         return false;
     }
+    Utils::LogDebug("[init-stage] After Dx12Hook::Initialize");
 
 	SDK::USBZSettingsFunctionsVideo::SetFramerateLimit(pGWorld, iFramerateLimit);
 	return true;

--- a/xmake.lua
+++ b/xmake.lua
@@ -17,7 +17,7 @@ set_targetdir(is_mode("debug") and "Build/Debug" or "Build/Release")
 set_runtimes(is_mode("debug") and "MTd" or "MT")
 
 add_requires("minhook")
-add_requires("imgui", {configs = {win32 = true, dx12 = true}, system = false})
+add_requires("imgui v1.91.9-docking", {configs = {win32 = true, dx12 = true}, system = false})
 
 target("Payday3-Internal")
     if has_config("avx2") then


### PR DESCRIPTION
xmake-repo now pulls ImGui >= 1.92, which moved font texture uploads behind a new backend contract (ImGuiBackendFlags_RendererHasTextures + ImTextureData). The bundled DX12 binding doesn't opt in, so the font atlas is never built and rendering fails on first frame.

Pinning to the last pre-1.92 release keeps the old implicit atlas upload path working. Also adds three LogDebug breadcrumbs around MH_Initialize / Dx12Hook::Initialize to make future init-stage regressions easier to locate from a log.